### PR TITLE
Introduce configurable API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ flutter pub get
 ```bash
 flutter run
 ```
+
+### Configuring the API Base URL
+The app uses a default API endpoint defined in `lib/backend/api_config.dart`. You can override this value at build time using Flutter's `--dart-define` option:
+
+```bash
+flutter run --dart-define=API_BASE_URL=https://your.api.server/api
+```
+
+When this variable is supplied, the `apiBaseUrl` constant is set to the provided value.
 🌐 Server API Setup (Ubuntu / Windows / Linux)
 1. Clone the server repository
 ```bash

--- a/lib/backend/api_config.dart
+++ b/lib/backend/api_config.dart
@@ -1,0 +1,4 @@
+const String apiBaseUrl = String.fromEnvironment(
+  'API_BASE_URL',
+  defaultValue: 'http://localhost:3000/api',
+);

--- a/lib/backend/expense/expense_api_service.dart
+++ b/lib/backend/expense/expense_api_service.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class ExpenseApiService {
-  final String baseUrl =
-      "http://your-api-url.com/expenses"; // Replace with actual API URL
+  final String baseUrl = '$apiBaseUrl/expenses';
 
   // Add a new expense
   Future<Map<String, dynamic>> addExpense(

--- a/lib/backend/expense/expense_approval_api_service.dart
+++ b/lib/backend/expense/expense_approval_api_service.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class ExpenseApprovalApiService {
-  final String baseUrl =
-      "http://your-api-url.com/expense-approvals"; // Replace with actual API URL
+  final String baseUrl = '$apiBaseUrl/expense-approvals';
 
   // Submit a new expense approval request
   Future<Map<String, dynamic>> submitApproval(

--- a/lib/backend/expense/expense_category_api_service.dart
+++ b/lib/backend/expense/expense_category_api_service.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class ExpenseCategoryApiService {
-  final String baseUrl =
-      "http://your-api-url.com/expense-categories"; // Replace with actual API URL
+  final String baseUrl = '$apiBaseUrl/expense-categories';
 
   // Add a new expense category
   Future<Map<String, dynamic>> addCategory(

--- a/lib/backend/expense/expense_subcategory_api_service.dart
+++ b/lib/backend/expense/expense_subcategory_api_service.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class ExpenseSubcategoryApiService {
-  final String baseUrl =
-      "http://your-api-url.com/expense-subcategories"; // Replace with actual API URL
+  final String baseUrl = '$apiBaseUrl/expense-subcategories';
 
   // Add a new expense subcategory
   Future<Map<String, dynamic>> addSubcategory(

--- a/lib/backend/guestmanage/promo_service.dart
+++ b/lib/backend/guestmanage/promo_service.dart
@@ -1,9 +1,10 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class PromoService {
-  static const String baseUrl = "https://your-api-url.com/promo-codes";
+  static const String baseUrl = '$apiBaseUrl/promo-codes';
 
   // Create a new promo code
   static Future<Map<String, dynamic>?> createPromoCode(

--- a/lib/backend/inventory/ingredient_api_service.dart
+++ b/lib/backend/inventory/ingredient_api_service.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class IngredientApiService {
-  final String baseUrl =
-      "http://your-api-url.com/ingredients"; // Replace with your actual API URL
+  final String baseUrl = '$apiBaseUrl/ingredients';
 
   // Get all ingredients
   Future<List<dynamic>> getAllIngredients() async {

--- a/lib/backend/inventory/ingredient_brand_api_service.dart
+++ b/lib/backend/inventory/ingredient_brand_api_service.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class IngredientBrandApiService {
-  final String baseUrl =
-      "http://your-api-url.com/ingredient-brands"; // Replace with actual API URL
+  final String baseUrl = '$apiBaseUrl/ingredient-brands';
 
   // Get all ingredient brands
   Future<List<dynamic>> getAllBrands() async {

--- a/lib/backend/inventory/ingredient_category_api_service.dart
+++ b/lib/backend/inventory/ingredient_category_api_service.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class IngredientCategoryApiService {
-  final String baseUrl =
-      "http://your-api-url.com/ingredient-categories"; // Replace with actual API URL
+  final String baseUrl = '$apiBaseUrl/ingredient-categories';
 
   // Get all ingredient categories
   Future<List<dynamic>> getAllCategories() async {

--- a/lib/backend/inventory/ingredient_subcategory_api_service.dart
+++ b/lib/backend/inventory/ingredient_subcategory_api_service.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class IngredientSubcategoryApiService {
-  final String baseUrl =
-      "http://your-api-url.com/ingredient-subcategories"; // Replace with actual API URL
+  final String baseUrl = '$apiBaseUrl/ingredient-subcategories';
 
   // Get all ingredient subcategories
   Future<List<dynamic>> getAllSubcategories() async {

--- a/lib/backend/inventory/purchase_service.dart
+++ b/lib/backend/inventory/purchase_service.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class PurchaseService {
-  final String baseUrl =
-      'http://your-api-url.com'; // Replace with your actual API URL
+  final String baseUrl = apiBaseUrl;
 
   Future<List<dynamic>> getAllPurchases() async {
     final response = await http.get(Uri.parse('$baseUrl/purchases'));

--- a/lib/backend/inventory/recipe_service.dart
+++ b/lib/backend/inventory/recipe_service.dart
@@ -1,9 +1,10 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class RecipeService {
-  static const String baseUrl = 'http://your-api-url.com';
+  static const String baseUrl = apiBaseUrl;
 
   // Fetch all recipes
   static Future<List<dynamic>> getAllRecipes() async {

--- a/lib/backend/loyalty/loyalty_program_api_service.dart
+++ b/lib/backend/loyalty/loyalty_program_api_service.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class LoyaltyProgramApiService {
-  final String baseUrl =
-      "http://your-api-url.com/loyalty-programs"; // Replace with your actual API URL
+  final String baseUrl = '$apiBaseUrl/loyalty-programs';
 
   // Get all loyalty programs
   Future<List<dynamic>> getAllLoyaltyPrograms() async {

--- a/lib/backend/loyalty/loyalty_redemption_service.dart
+++ b/lib/backend/loyalty/loyalty_redemption_service.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class LoyaltyRedemptionService {
-  final String baseUrl =
-      "http://your-api-url.com/redemption-limits"; // Replace with actual API URL
+  final String baseUrl = '$apiBaseUrl/redemption-limits';
 
   // Create a new redemption limit
   Future<Map<String, dynamic>> createRedemptionLimit(

--- a/lib/backend/loyalty/loyalty_transaction_service.dart
+++ b/lib/backend/loyalty/loyalty_transaction_service.dart
@@ -1,9 +1,10 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class LoyaltyTransactionService {
-  final String baseUrl = "https://your-api-url.com/loyalty-transactions";
+  final String baseUrl = '$apiBaseUrl/loyalty-transactions';
 
   Future<Map<String, dynamic>> createTransaction(
       {required int guestId,

--- a/lib/backend/payroll/benefit_api_service.dart
+++ b/lib/backend/payroll/benefit_api_service.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class BenefitApiService {
-  final String baseUrl =
-      "http://your-api-url.com/benefits"; // Replace with actual API URL
+  final String baseUrl = '$apiBaseUrl/benefits';
 
   // Create a new benefit
   Future<Map<String, dynamic>> createBenefit(

--- a/lib/backend/payroll/earning_service.dart
+++ b/lib/backend/payroll/earning_service.dart
@@ -1,9 +1,10 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class EarningService {
-  final String baseUrl = "http://your-api-url.com/staff-earnings";
+  final String baseUrl = '$apiBaseUrl/staff-earnings';
 
   // Add a new earning record
   Future<Map<String, dynamic>?> addEarning(

--- a/lib/backend/payroll/employee_api_service.dart
+++ b/lib/backend/payroll/employee_api_service.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class EmployeeApiService {
-  final String baseUrl =
-      "http://your-api-url.com/employees"; // Replace with actual API URL
+  final String baseUrl = '$apiBaseUrl/employees';
 
   // Create Employee
   Future<Map<String, dynamic>> createEmployee(

--- a/lib/backend/payroll/salary_advance_service.dart
+++ b/lib/backend/payroll/salary_advance_service.dart
@@ -1,9 +1,10 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class SalaryAdvanceService {
-  final String baseUrl = "http://your-api-url.com/salary-advances";
+  final String baseUrl = '$apiBaseUrl/salary-advances';
 
   Future<Map<String, dynamic>?> addSalaryAdvance(
       {required int employeeId,

--- a/lib/backend/payroll/salary_service.dart
+++ b/lib/backend/payroll/salary_service.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class SalaryService {
-  static const String baseUrl =
-      'http://your-api-url.com/salaries'; // Replace with your API URL
+  static const String baseUrl = '$apiBaseUrl/salaries';
 
   // Add a new salary record
   static Future<Map<String, dynamic>?> addSalary(

--- a/lib/backend/settings/payment_method_service.dart
+++ b/lib/backend/settings/payment_method_service.dart
@@ -1,9 +1,10 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class PaymentMethodService {
-  final String baseUrl = "https://your-api-url.com/payment-methods";
+  final String baseUrl = '$apiBaseUrl/payment-methods';
 
   Future<Map<String, dynamic>?> addPaymentMethod(
       String methodName, String description) async {

--- a/lib/backend/settings/property_service.dart
+++ b/lib/backend/settings/property_service.dart
@@ -1,8 +1,9 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class PropertyService {
-  final String _baseUrl = "http://localhost:3000/api";
+  final String _baseUrl = apiBaseUrl;
 
   Future<Map<String, dynamic>> createProperty({
     required int propertyId,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,11 +6,11 @@ import 'package:point_of_sale_system/model/packing_charge_model.dart';
 import 'package:point_of_sale_system/model/service_charge_model.dart';
 
 import 'backend/settings/outlet_service.dart';
+import 'backend/api_config.dart';
 import 'model/delivery_charge_model.dart';
 import 'screens/users/poslogin.dart';
 
-final OutletApiService apiService =
-    OutletApiService(baseUrl: 'http://localhost:3000/api');
+final OutletApiService apiService = OutletApiService(baseUrl: apiBaseUrl);
 void main() async {
   await _initializeHive();
   Hive.registerAdapter(DiscountModelAdapter()); // Register the adapter

--- a/lib/screens/admin/admin.dart
+++ b/lib/screens/admin/admin.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:point_of_sale_system/screens/payroll/payrollDashboard.dart';
 
 import '../../backend/billing/bill_service.dart';
+import '../../backend/api_config.dart';
 import '../billing/billconfig.dart';
 import '../billing/guest_info.dart';
 import '../expense/expenseDashboard.dart';
@@ -45,7 +46,7 @@ class _AdminDashboard extends State {
   final List<String> outlets = ['Outlet1', 'Outlet2'];
   ChartType chartType = ChartType.line;
   final BillingApiService billingApiService =
-      BillingApiService(baseUrl: 'http://localhost:3000/api');
+      BillingApiService(baseUrl: apiBaseUrl);
   String today_growth = "0";
   String today_sales = "0";
   String this_week_sales = "0";

--- a/lib/screens/billing/bill_old.dart
+++ b/lib/screens/billing/bill_old.dart
@@ -8,6 +8,7 @@ import 'package:pdf/widgets.dart' as pw;
 
 import '../../backend/billing/bill_service.dart';
 import '../../backend/order/OrderApiService.dart';
+import '../../backend/api_config.dart';
 import '../orders/modifyOrder.dart';
 
 class OldBillPage extends StatefulWidget {
@@ -20,10 +21,8 @@ class OldBillPage extends StatefulWidget {
 }
 
 class _OldBillPageState extends State<OldBillPage> {
-  BillingApiService billApiService =
-      BillingApiService(baseUrl: 'http://localhost:3000/api');
-  OrderApiService orderApiService =
-      OrderApiService(baseUrl: 'http://localhost:3000/api');
+  BillingApiService billApiService = BillingApiService(baseUrl: apiBaseUrl);
+  OrderApiService orderApiService = OrderApiService(baseUrl: apiBaseUrl);
   List<Map<String, String>> _bills = [];
   final List<Map<String, String>> _billsdata = [];
   List<Map<String, dynamic>> orders = [];

--- a/lib/screens/billing/bill_section.dart
+++ b/lib/screens/billing/bill_section.dart
@@ -8,6 +8,7 @@ import 'package:pdf/widgets.dart' as pw;
 
 import '../../backend/billing/bill_service.dart';
 import '../../backend/order/OrderApiService.dart';
+import '../../backend/api_config.dart';
 import '../orders/modifyOrder.dart';
 
 class BillPage extends StatefulWidget {
@@ -20,10 +21,8 @@ class BillPage extends StatefulWidget {
 }
 
 class _BillPageState extends State<BillPage> {
-  BillingApiService billApiService =
-      BillingApiService(baseUrl: 'http://localhost:3000/api');
-  OrderApiService orderApiService =
-      OrderApiService(baseUrl: 'http://localhost:3000/api');
+  BillingApiService billApiService = BillingApiService(baseUrl: apiBaseUrl);
+  OrderApiService orderApiService = OrderApiService(baseUrl: apiBaseUrl);
   List<Map<String, String>> _bills = [];
   final List<Map<String, String>> _billsdata = [];
   List<Map<String, dynamic>> orders = [];

--- a/lib/screens/billing/billconfig.dart
+++ b/lib/screens/billing/billconfig.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../backend/settings/bill_api_service.dart';
+import '../../backend/api_config.dart';
 
 class BillConfigurationForm extends StatefulWidget {
   const BillConfigurationForm({super.key});
@@ -12,8 +13,7 @@ class BillConfigurationForm extends StatefulWidget {
 
 class _BillConfigurationFormState extends State<BillConfigurationForm> {
   final _formKey = GlobalKey<FormState>();
-  final BillApiService apiService = BillApiService(
-      'http://localhost:3000/api/bill-config'); // Update with your backend URL
+  final BillApiService apiService = BillApiService('$apiBaseUrl/bill-config');
   String? selectedOutlet;
   String billPrefix = '';
   String? billSuffix;

--- a/lib/screens/billing/billing.dart
+++ b/lib/screens/billing/billing.dart
@@ -13,6 +13,7 @@ import '../../backend/settings/deliveryApiService.dart';
 import '../../backend/settings/discountApiService.dart';
 import '../../backend/settings/packingChargeApiService.dart';
 import '../../backend/settings/serviceChargeApiService.dart';
+import '../../backend/api_config.dart';
 
 class BillingFormScreen extends StatefulWidget {
   final tableno;
@@ -29,18 +30,16 @@ class BillingFormScreen extends StatefulWidget {
 }
 
 class _BillingFormScreenState extends State<BillingFormScreen> {
-  BillingApiService billingApiService =
-      BillingApiService(baseUrl: 'http://localhost:3000/api');
-  OrderApiService orderApiService =
-      OrderApiService(baseUrl: 'http://localhost:3000/api');
+  BillingApiService billingApiService = BillingApiService(baseUrl: apiBaseUrl);
+  OrderApiService orderApiService = OrderApiService(baseUrl: apiBaseUrl);
   GuestRecordApiService guestRecordApiService =
-      GuestRecordApiService(baseUrl: 'http://localhost:3000/api');
+      GuestRecordApiService(baseUrl: apiBaseUrl);
   DiscountApiService discountApiService =
-      DiscountApiService(baseUrl: 'http://localhost:3000/api');
+      DiscountApiService(baseUrl: apiBaseUrl);
   PackingChargeApiService packingApiService =
-      PackingChargeApiService(baseUrl: 'http://localhost:3000/api');
+      PackingChargeApiService(baseUrl: apiBaseUrl);
   DeliveryApiService deliveryApiService =
-      DeliveryApiService(baseUrl: 'http://localhost:3000/api');
+      DeliveryApiService(baseUrl: apiBaseUrl);
   List<Map<dynamic, dynamic>> discountList = [
     {}
   ]; // Variable to store discounts
@@ -51,7 +50,7 @@ class _BillingFormScreenState extends State<BillingFormScreen> {
   List<Map<dynamic, dynamic>> serviceList = [{}]; // Variable to store discounts
 
   ServiceChargeApiService serviceChargeApiService =
-      ServiceChargeApiService(baseUrl: 'http://localhost:3000/api');
+      ServiceChargeApiService(baseUrl: apiBaseUrl);
 
   final TextEditingController _billNoController = TextEditingController();
   final TextEditingController _orderNoController =

--- a/lib/screens/billing/guest_info.dart
+++ b/lib/screens/billing/guest_info.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../backend/guestmanage/guest_record_api_service.dart';
+import '../../backend/api_config.dart';
 
 class GuestRegistrationScreen extends StatefulWidget {
   const GuestRegistrationScreen({super.key});
@@ -15,7 +16,7 @@ class GuestRegistrationScreen extends StatefulWidget {
 class _GuestRegistrationScreenState extends State<GuestRegistrationScreen> {
   final _formKey = GlobalKey<FormState>();
   final GuestRecordApiService apiService =
-      GuestRecordApiService(baseUrl: 'http://localhost:3000/api');
+      GuestRecordApiService(baseUrl: apiBaseUrl);
   final String _guestId = 'G100'; // Set default Guest ID
   String? _guestName;
   String? _phoneNumber;

--- a/lib/screens/billing/payments.dart
+++ b/lib/screens/billing/payments.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 
 import '../../backend/billing/bill_service.dart';
 import '../../backend/billing/paymentApiService.dart';
+import '../../backend/api_config.dart';
 
 class PaymentFormScreen extends StatefulWidget {
   final tableno;
@@ -21,9 +22,9 @@ class PaymentFormScreen extends StatefulWidget {
 
 class _PaymentFormScreenState extends State<PaymentFormScreen> {
   PaymentApiService paymentApiService =
-      PaymentApiService(baseUrl: 'http://localhost:3000/api');
+      PaymentApiService(baseUrl: apiBaseUrl);
   BillingApiService billApiService =
-      BillingApiService(baseUrl: 'http://localhost:3000/api');
+      BillingApiService(baseUrl: apiBaseUrl);
   final _formKey = GlobalKey<FormState>();
   String? _paymentMethod;
   double _amount = 0.0;

--- a/lib/screens/orders/kotform.dart
+++ b/lib/screens/orders/kotform.dart
@@ -7,6 +7,7 @@ import 'package:pdf/widgets.dart' as pw;
 import '../../backend/order/OrderApiService.dart';
 import '../../backend/order/items_api_service.dart';
 import '../../backend/order/waiterApiService.dart';
+import '../../backend/api_config.dart';
 
 class KOTFormScreen extends StatefulWidget {
   final tableno;
@@ -23,12 +24,9 @@ class KOTFormScreen extends StatefulWidget {
 }
 
 class _KOTFormScreenState extends State<KOTFormScreen> {
-  OrderApiService orderApiService =
-      OrderApiService(baseUrl: 'http://localhost:3000/api');
-  ItemsApiService itemsApiService =
-      ItemsApiService(baseUrl: 'http://localhost:3000/api');
-  WaiterApiService waiterApiService =
-      WaiterApiService(baseUrl: 'http://localhost:3000/api');
+  OrderApiService orderApiService = OrderApiService(baseUrl: apiBaseUrl);
+  ItemsApiService itemsApiService = ItemsApiService(baseUrl: apiBaseUrl);
+  WaiterApiService waiterApiService = WaiterApiService(baseUrl: apiBaseUrl);
   final List<String> _categories = ['Starters', 'Main Course', 'Desserts'];
   late Future<Map<String, List<Map<String, String>>>> _menuItemsFuture;
   // Menu items with their tags (Veg/Non-Veg) and rate

--- a/lib/screens/orders/modifyOrder.dart
+++ b/lib/screens/orders/modifyOrder.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../backend/order/OrderApiService.dart';
 import '../../backend/order/items_api_service.dart';
+import '../../backend/api_config.dart';
 
 class ModifyOrderList extends StatefulWidget {
   final propertyid;
@@ -19,11 +20,9 @@ class ModifyOrderList extends StatefulWidget {
 }
 
 class _ModifyOrderListState extends State<ModifyOrderList> {
-  OrderApiService orderApiService =
-      OrderApiService(baseUrl: 'http://localhost:3000/api');
+  OrderApiService orderApiService = OrderApiService(baseUrl: apiBaseUrl);
   final List<String> _categories = ['Starters', 'Main Course', 'Desserts'];
-  ItemsApiService itemsApiService =
-      ItemsApiService(baseUrl: 'http://localhost:3000/api');
+  ItemsApiService itemsApiService = ItemsApiService(baseUrl: apiBaseUrl);
   late Future<Map<String, List<Map<String, String>>>> _menuItemsFuture;
   // Menu items with their tags (Veg/Non-Veg) and rate
   final Map<String, List<Map<String, String>>> _menuItems = {

--- a/lib/screens/orders/orderlist.dart
+++ b/lib/screens/orders/orderlist.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../backend/order/OrderApiService.dart';
+import '../../backend/api_config.dart';
 import 'modifyOrder.dart';
 
 class OrderList extends StatefulWidget {
@@ -14,7 +15,7 @@ class OrderList extends StatefulWidget {
 
 class _OrderListState extends State<OrderList> {
   OrderApiService orderApiService =
-      OrderApiService(baseUrl: 'http://localhost:3000/api');
+      OrderApiService(baseUrl: apiBaseUrl);
   List<Map<String, dynamic>> orders = [];
   List<Map<String, dynamic>> orderItems = [];
   var selectedOrderId;

--- a/lib/screens/orders/posmain.dart
+++ b/lib/screens/orders/posmain.dart
@@ -4,6 +4,7 @@ import 'package:socket_io_client/socket_io_client.dart' as IO;
 
 import '../../backend/billing/bill_service.dart';
 import '../../backend/order/table_api_service.dart';
+import '../../backend/api_config.dart';
 import '../admin/admin.dart';
 import '../billing/bill_section.dart';
 import '../billing/billing.dart';
@@ -27,9 +28,9 @@ class POSMainScreen extends StatefulWidget {
 }
 
 class _POSMainScreenState extends State<POSMainScreen> {
-  final tableapiService = TableApiService(apiUrl: 'http://localhost:3000/api');
+  final tableapiService = TableApiService(apiUrl: apiBaseUrl);
   final BillingApiService billingApiService =
-      BillingApiService(baseUrl: 'http://localhost:3000/api');
+      BillingApiService(baseUrl: apiBaseUrl);
   String today_reservations = "0";
   String today_sales = "0";
   String running_orders = "0";
@@ -108,7 +109,7 @@ class _POSMainScreenState extends State<POSMainScreen> {
   }
 
   void _initializeWebSocket() {
-    socket = IO.io('http://localhost:3000', <String, dynamic>{
+    socket = IO.io(apiBaseUrl.replaceFirst('/api', ''), <String, dynamic>{
       'transports': ['websocket'], // Force WebSocket transport
       'autoConnect': true,
     });

--- a/lib/screens/orders/waiters.dart
+++ b/lib/screens/orders/waiters.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:point_of_sale_system/backend/order/waiterApiService.dart';
+import '../../backend/api_config.dart';
 
 class WaiterConfigurationForm extends StatefulWidget {
   @override
@@ -10,7 +11,7 @@ class WaiterConfigurationForm extends StatefulWidget {
 
 class _WaiterConfigurationFormState extends State<WaiterConfigurationForm> {
   WaiterApiService waiterApiService =
-      WaiterApiService(baseUrl: 'http://localhost:3000/api');
+      WaiterApiService(baseUrl: apiBaseUrl);
 
   final _formKey = GlobalKey<FormState>();
   String? selectedOutlet;

--- a/lib/screens/reports/reports.dart
+++ b/lib/screens/reports/reports.dart
@@ -5,6 +5,7 @@ import 'package:csv/csv.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
+import '../../backend/api_config.dart';
 import 'package:syncfusion_flutter_charts/charts.dart';
 
 class ReportScreen extends StatefulWidget {
@@ -15,7 +16,7 @@ class ReportScreen extends StatefulWidget {
 }
 
 class _ReportScreenState extends State<ReportScreen> {
-  final String baseUrl = 'http://localhost:3000/api/bill/reports';
+  final String baseUrl = '$apiBaseUrl/bill/reports';
   List<Map<String, dynamic>> reportData = [];
   String? selectedReport;
 

--- a/lib/screens/rservation/reservation.dart
+++ b/lib/screens/rservation/reservation.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../backend/reservation/reservationApiService.dart';
+import '../../backend/api_config.dart';
 
 class ReservationFormScreen extends StatefulWidget {
   const ReservationFormScreen({super.key});
@@ -13,7 +14,7 @@ class ReservationFormScreen extends StatefulWidget {
 
 class _ReservationFormScreenState extends State<ReservationFormScreen> {
   ReservationApiService reservationApiService =
-      ReservationApiService(baseUrl: 'http://localhost:3000/api');
+      ReservationApiService(baseUrl: apiBaseUrl);
   final _formKey = GlobalKey<FormState>();
   String? _guestName;
   String? _contactInfo;

--- a/lib/screens/settings/ItemManage.dart
+++ b/lib/screens/settings/ItemManage.dart
@@ -11,6 +11,7 @@ import 'package:open_file/open_file.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../../backend/order/items_api_service.dart';
+import '../../backend/api_config.dart';
 
 class ItemMasterScreen extends StatefulWidget {
   const ItemMasterScreen({super.key});
@@ -20,8 +21,8 @@ class ItemMasterScreen extends StatefulWidget {
 }
 
 class _ItemMasterScreenState extends State<ItemMasterScreen> {
-  final ItemsApiService _apiService = ItemsApiService(
-      baseUrl: 'http://localhost:3000/api'); // Replace with actual base URL
+  final ItemsApiService _apiService =
+      ItemsApiService(baseUrl: apiBaseUrl); // Replace with actual base URL
   final List<String> _categories = ['Starters', 'Main Course', 'Desserts'];
   final List<String> tags = ['Veg', 'Non Veg'];
   final List<String> _brands = ['Brand A', 'Brand B', 'Brand C'];

--- a/lib/screens/settings/dateconfig.dart
+++ b/lib/screens/settings/dateconfig.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../backend/settings/date_config_api_service.dart';
+import '../../backend/api_config.dart';
 
 class SoftwareDateConfigForm extends StatefulWidget {
   const SoftwareDateConfigForm({super.key});
@@ -12,7 +13,7 @@ class SoftwareDateConfigForm extends StatefulWidget {
 
 class _SoftwareDateConfigFormState extends State<SoftwareDateConfigForm> {
   DateConfigApiService dateConfigApiService =
-      DateConfigApiService(baseUrl: 'http://localhost:3000/api');
+      DateConfigApiService(baseUrl: apiBaseUrl);
 
   final _formKey = GlobalKey<FormState>();
   String? _selectedOutlet;

--- a/lib/screens/settings/deliveryCharge.dart
+++ b/lib/screens/settings/deliveryCharge.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../backend/settings/deliveryApiService.dart';
+import '../../backend/api_config.dart';
 
 class DeliveryChargeConfigForm extends StatefulWidget {
   const DeliveryChargeConfigForm({super.key});
@@ -14,7 +15,7 @@ class DeliveryChargeConfigForm extends StatefulWidget {
 
 class _DeliveryChargeConfigFormState extends State<DeliveryChargeConfigForm> {
   DeliveryApiService deliveryApiService =
-      DeliveryApiService(baseUrl: 'http://localhost:3000/api');
+      DeliveryApiService(baseUrl: apiBaseUrl);
   final _formKey = GlobalKey<FormState>();
   final _chargePercentageController = TextEditingController();
   final _minAmountController = TextEditingController();

--- a/lib/screens/settings/discountConfig.dart
+++ b/lib/screens/settings/discountConfig.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../backend/settings/discountApiService.dart';
+import '../../backend/api_config.dart';
 
 class DiscountConfigForm extends StatefulWidget {
   const DiscountConfigForm({super.key});
@@ -13,7 +14,7 @@ class DiscountConfigForm extends StatefulWidget {
 
 class _DiscountConfigFormState extends State<DiscountConfigForm> {
   DiscountApiService discountApiService =
-      DiscountApiService(baseUrl: 'http://localhost:3000/api');
+      DiscountApiService(baseUrl: apiBaseUrl);
   final _formKey = GlobalKey<FormState>();
   final _feePercentageController = TextEditingController();
   final _minAmountController = TextEditingController();

--- a/lib/screens/settings/kotconfig.dart
+++ b/lib/screens/settings/kotconfig.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../backend/settings/kotConfigApiService.dart';
+import '../../backend/api_config.dart';
 
 class KOTConfigForm extends StatefulWidget {
   const KOTConfigForm({super.key});
@@ -13,7 +14,7 @@ class KOTConfigForm extends StatefulWidget {
 
 class _KOTConfigFormState extends State<KOTConfigForm> {
   KOTConfigApiService kotConfigApiService =
-      KOTConfigApiService(baseUrl: 'http://localhost:3000/api');
+      KOTConfigApiService(baseUrl: apiBaseUrl);
   final _formKey = GlobalKey<FormState>();
   int kotStartingNumber = 1;
   DateTime? startDate;

--- a/lib/screens/settings/outletconfig.dart
+++ b/lib/screens/settings/outletconfig.dart
@@ -3,6 +3,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../../backend/settings/outlet_service.dart';
+import '../../backend/api_config.dart';
 
 class OutletConfigurationForm extends StatefulWidget {
   const OutletConfigurationForm({super.key});
@@ -14,7 +15,7 @@ class OutletConfigurationForm extends StatefulWidget {
 
 class _OutletConfigurationFormState extends State<OutletConfigurationForm> {
   final OutletApiService apiService =
-      OutletApiService(baseUrl: 'http://localhost:3000/api');
+      OutletApiService(baseUrl: apiBaseUrl);
   List<dynamic> properties = [];
   List<dynamic> outletConfigurations = [];
   bool isLoading = true;

--- a/lib/screens/settings/packingCharge.dart
+++ b/lib/screens/settings/packingCharge.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../backend/settings/packingChargeApiService.dart';
+import '../../backend/api_config.dart';
 
 class PackingChargeConfigForm extends StatefulWidget {
   const PackingChargeConfigForm({super.key});
@@ -14,7 +15,7 @@ class PackingChargeConfigForm extends StatefulWidget {
 
 class _PackingChargeConfigFormState extends State<PackingChargeConfigForm> {
   PackingChargeApiService packingChargeApiService =
-      PackingChargeApiService(baseUrl: 'http://localhost:3000/api');
+      PackingChargeApiService(baseUrl: apiBaseUrl);
   final _formKey = GlobalKey<FormState>();
   final _chargePercentageController = TextEditingController();
   final _minAmountController = TextEditingController();

--- a/lib/screens/settings/platformfe.dart
+++ b/lib/screens/settings/platformfe.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../backend/settings/platformFeeApiService.dart';
+import '../../backend/api_config.dart';
 
 class platformFeeConfigForm extends StatefulWidget {
   const platformFeeConfigForm({super.key});
@@ -13,7 +14,7 @@ class platformFeeConfigForm extends StatefulWidget {
 
 class _platformFeeConfigFormState extends State<platformFeeConfigForm> {
   PlatformFeeApiService platformFeeApiService =
-      PlatformFeeApiService(baseUrl: 'http://localhost:3000/api');
+      PlatformFeeApiService(baseUrl: apiBaseUrl);
   final _formKey = GlobalKey<FormState>();
   final _feePercentageController = TextEditingController();
   final _minAmountController = TextEditingController();

--- a/lib/screens/settings/printer.dart
+++ b/lib/screens/settings/printer.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../backend/settings/printerApiService.dart';
+import '../../backend/api_config.dart';
 
 class PrinterConfigForm extends StatefulWidget {
   const PrinterConfigForm({super.key});
@@ -14,7 +15,7 @@ class PrinterConfigForm extends StatefulWidget {
 class _PrinterConfigFormState extends State<PrinterConfigForm> {
   final _formKey = GlobalKey<FormState>();
   PrinterApiService printerApiService =
-      PrinterApiService(baseUrl: 'http://localhost:3000/api');
+      PrinterApiService(baseUrl: apiBaseUrl);
   TextEditingController printerNumberController = TextEditingController();
   String printerName = '';
   String printerType = 'receipt';

--- a/lib/screens/settings/propertyinfo.dart
+++ b/lib/screens/settings/propertyinfo.dart
@@ -3,6 +3,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../../backend/settings/outlet_service.dart';
+import '../../backend/api_config.dart';
 import '../../backend/settings/property_service.dart';
 
 class PropertyConfigurationForm extends StatefulWidget {
@@ -36,7 +37,7 @@ class _PropertyConfigurationFormState extends State<PropertyConfigurationForm> {
   }
 
   final OutletApiService apiService =
-      OutletApiService(baseUrl: 'http://localhost:3000/api');
+      OutletApiService(baseUrl: apiBaseUrl);
   List<dynamic> properties = [];
   List<dynamic> outletConfigurations = [];
 

--- a/lib/screens/settings/servicecharge.dart
+++ b/lib/screens/settings/servicecharge.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../backend/settings/serviceChargeApiService.dart';
+import '../../backend/api_config.dart';
 
 class ServiceChargeConfigForm extends StatefulWidget {
   const ServiceChargeConfigForm({super.key});
@@ -14,7 +15,7 @@ class ServiceChargeConfigForm extends StatefulWidget {
 
 class _ServiceChargeConfigFormState extends State<ServiceChargeConfigForm> {
   ServiceChargeApiService serviceChargeApiService =
-      ServiceChargeApiService(baseUrl: 'http://localhost:3000/api');
+      ServiceChargeApiService(baseUrl: apiBaseUrl);
   final _formKey = GlobalKey<FormState>();
   final _chargePercentageController = TextEditingController();
   final _minAmountController = TextEditingController();

--- a/lib/screens/settings/tablemaster.dart
+++ b/lib/screens/settings/tablemaster.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../backend/order/table_api_service.dart';
+import '../../backend/api_config.dart';
 
 class TableManagementPage extends StatefulWidget {
   const TableManagementPage({super.key});
@@ -17,13 +18,12 @@ class _TableManagementPageState extends State<TableManagementPage> {
   String? _selectedOutlet; // Outlet selection
   List<Map<String, dynamic>> _tables = [];
   List<String> outlets = []; // Example outlets
-  final String apiUrl =
-      'http://localhost:3000/api'; // Replace with your backend API URL
+  final String apiUrl = apiBaseUrl;
   List<dynamic> properties = [];
   List<dynamic> outletConfigurations = [];
 
-  final TableApiService _tableApiService = TableApiService(
-      apiUrl: 'http://localhost:3000/api'); // Create the service instance
+  final TableApiService _tableApiService =
+      TableApiService(apiUrl: apiBaseUrl); // Create the service instance
 
   // Fetch table configurations
   Future<void> _fetchTableConfigs() async {

--- a/lib/screens/settings/taxconfig.dart
+++ b/lib/screens/settings/taxconfig.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../backend/settings/taxConfigApiService.dart';
+import '../../backend/api_config.dart';
 
 class TaxConfigForm extends StatefulWidget {
   const TaxConfigForm({super.key});
@@ -18,7 +19,7 @@ class _TaxConfigFormState extends State<TaxConfigForm> {
   final _greaterthanController = TextEditingController();
   final _lessthanController = TextEditingController();
   final TaxConfigApiService taxApiService =
-      TaxConfigApiService(baseUrl: 'http://localhost:3000/api');
+      TaxConfigApiService(baseUrl: apiBaseUrl);
   String _taxType = 'exclusive'; // Default tax type
   String? _selectedOutlet; // To store the selected outlet
 

--- a/lib/screens/settings/usermaster.dart
+++ b/lib/screens/settings/usermaster.dart
@@ -3,6 +3,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../../backend/settings/user_api_service.dart';
+import '../../backend/api_config.dart';
 
 class UserProfilePage extends StatefulWidget {
   const UserProfilePage({super.key});
@@ -15,8 +16,7 @@ class _UserProfilePageState extends State<UserProfilePage> {
   final _formKey = GlobalKey<FormState>();
   final TextEditingController _dobController = TextEditingController();
   final TextEditingController _joinDateController = TextEditingController();
-  UserApiService userApiService =
-      UserApiService(baseUrl: 'http://localhost:3000/api');
+  UserApiService userApiService = UserApiService(baseUrl: apiBaseUrl);
   String? _username;
   String? _fullName;
   DateTime _dob = DateTime(1990, 1, 1);

--- a/lib/screens/settings/userpermission.dart
+++ b/lib/screens/settings/userpermission.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:point_of_sale_system/backend/settings/user_permissions.dart';
+import '../../backend/api_config.dart';
 
 class UserPermissionForm extends StatefulWidget {
   const UserPermissionForm({super.key});
@@ -12,7 +13,7 @@ class UserPermissionForm extends StatefulWidget {
 class _UserPermissionFormState extends State<UserPermissionForm> {
   final _formKey = GlobalKey<FormState>();
   UserPermissionApiService userPermissionApiService =
-      UserPermissionApiService(baseUrl: 'http://localhost:3000/api');
+      UserPermissionApiService(baseUrl: apiBaseUrl);
   List<String> selectedOutlets = [];
   List<String> selectedUsers = []; // List to store selected user ids
   Map<String, List<String>> userPermissions =


### PR DESCRIPTION
## Summary
- centralize API base URL in `lib/backend/api_config.dart`
- update services and screens to use `apiBaseUrl`
- document overriding the value via `--dart-define`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68556955b6e08328a826a1e51ab82b2e