### PR TITLE
Default payroll services to global API base

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ flutter run --dart-define=API_BASE_URL=https://your.api.server/api
 ```
 
 When this variable is supplied, the `apiBaseUrl` constant is set to the provided value.
+All backend service classes use this base URL by default. For example, the
+`AttendanceApiService` and `AccountApiService` will automatically point to
+`apiBaseUrl` unless a custom URL is supplied when constructing them.
 🌐 Server API Setup (Ubuntu / Windows / Linux)
 1. Install Node.js dependencies in the project root
 ```bash

--- a/lib/backend/payroll/account_api_service.dart
+++ b/lib/backend/payroll/account_api_service.dart
@@ -1,11 +1,13 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class AccountApiService {
   final String baseUrl;
 
-  AccountApiService(this.baseUrl);
+  AccountApiService({String? baseUrl})
+      : baseUrl = baseUrl ?? apiBaseUrl;
 
   // Create a new account
   Future<Map<String, dynamic>> createAccount(

--- a/lib/backend/payroll/attendance_api_service.dart
+++ b/lib/backend/payroll/attendance_api_service.dart
@@ -1,11 +1,13 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class AttendanceApiService {
   final String baseUrl;
 
-  AttendanceApiService(this.baseUrl);
+  AttendanceApiService({String? baseUrl})
+      : baseUrl = baseUrl ?? apiBaseUrl;
 
   // Add an attendance record
   Future<Map<String, dynamic>> addAttendance(


### PR DESCRIPTION
## Summary
- use `apiBaseUrl` in attendance and account services if none provided
- mention service defaults in README

## Testing
- `dart format -o none --set-exit-if-changed lib/backend/payroll/attendance_api_service.dart lib/backend/payroll/account_api_service.dart README.md`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6856622cd92c8328bd8cba3a7d475d73