### PR TITLE
Add example env and update README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+PORT=5000
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=your_db_user
+DB_PASSWORD=your_db_password
+DB_DATABASE=your_db_name

--- a/README.md
+++ b/README.md
@@ -141,13 +141,17 @@ npm install
 ```
 2. Set up environment variables
 ```bash
-Create a `.env` file in the root directory and add the following:
+cp .env.example .env
+```
+Then edit `.env` with your database settings. The example file contains:
 
+```
 PORT=5000
-DB_HOST=your_db_host
+DB_HOST=localhost
+DB_PORT=5432
 DB_USER=your_db_user
 DB_PASSWORD=your_db_password
-DB_NAME=your_db_name
+DB_DATABASE=your_db_name
 ```
 3. Run the server
 ```bash


### PR DESCRIPTION
## Summary
- add `.env.example` file with default environment variables
- update README setup instructions to copy `.env.example` to `.env`
- replace `DB_NAME` with `DB_DATABASE` and mention `DB_PORT`
- script already copies `.env.example` when `.env` is missing

## Testing
- `flutter test` *(fails: command not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856697d5a308328a8450f8b3ea257d2