### PR TITLE
Fix error message on bill save failure

### DIFF
--- a/lib/screens/billing/billing.dart
+++ b/lib/screens/billing/billing.dart
@@ -556,7 +556,7 @@ class _BillingFormScreenState extends State<BillingFormScreen> {
           "1");
       _clearControllers();
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Bill saved successfully!')),
+        SnackBar(content: Text('Failed to save bill: $error')),
       );
       print('Error: $error');
       // ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
## Summary
- ensure billing page shows an error message when saving a bill fails instead of a success message

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68566c41a40c83289dbbbeb202c2da1c