### PR TITLE
Refactor backend services

### DIFF
--- a/lib/backend/billing/bill_service.dart
+++ b/lib/backend/billing/bill_service.dart
@@ -1,11 +1,12 @@
 import 'dart:convert';
-
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class BillingApiService {
   final String baseUrl;
 
-  BillingApiService({required this.baseUrl});
+  BillingApiService({String? baseUrl})
+      : baseUrl = baseUrl ?? apiBaseUrl;
 
   // 1. GET: Fetch Bill Details by Order ID
   Future<Map<String, dynamic>> getBill(String orderId) async {

--- a/lib/backend/billing/paymentApiService.dart
+++ b/lib/backend/billing/paymentApiService.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class PaymentApiService {
   final String baseUrl;
 
-  PaymentApiService({required this.baseUrl});
+  PaymentApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   // 1. Get all payments
   Future<List<Map<String, dynamic>>> getPayments() async {

--- a/lib/backend/billing/report_api_service.dart
+++ b/lib/backend/billing/report_api_service.dart
@@ -1,11 +1,12 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class ReportApiService {
   final String baseUrl;
 
-  ReportApiService({required this.baseUrl});
+  ReportApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   //  Get Daily Sales Summary
   Future<Map<String, dynamic>> getDailySales() async {

--- a/lib/backend/guestmanage/feedback_api_service.dart
+++ b/lib/backend/guestmanage/feedback_api_service.dart
@@ -1,11 +1,12 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class FeedbackApiService {
   final String baseUrl;
 
-  FeedbackApiService(this.baseUrl);
+  FeedbackApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   // Add new feedback
   Future<Map<String, dynamic>> addFeedback(

--- a/lib/backend/guestmanage/guest_record_api_service.dart
+++ b/lib/backend/guestmanage/guest_record_api_service.dart
@@ -1,11 +1,13 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import 'dart:developer';
+import '../api_config.dart';
 
 class GuestRecordApiService {
   final String baseUrl;
 
-  GuestRecordApiService({required this.baseUrl});
+  GuestRecordApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   // 1. Create a new guest record
   Future<Map<String, dynamic>> createGuestRecord(
@@ -42,7 +44,7 @@ class GuestRecordApiService {
 
   Future<List<Map<String, dynamic>>> searchRecords(String query) async {
     if (query.trim().isEmpty) {
-      print("Search query is empty, skipping API call.");
+      log('Search query is empty, skipping API call.');
       return [];
     }
 
@@ -57,11 +59,11 @@ class GuestRecordApiService {
         List<dynamic> data = json.decode(response.body);
         return List<Map<String, dynamic>>.from(data);
       } else {
-        print("Error: ${response.body}");
+        log('Error: ${response.body}');
         throw Exception('Failed to fetch guest records: ${response.body}');
       }
     } catch (e) {
-      print("Exception: $e");
+      log('Exception: $e');
       return [];
     }
   }

--- a/lib/backend/inventory/InventoryApiService.dart
+++ b/lib/backend/inventory/InventoryApiService.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class InventoryApiService {
   final String baseUrl;
 
-  InventoryApiService({required this.baseUrl});
+  InventoryApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   // 1. Create a new inventory transaction
   Future<Map<String, dynamic>> createInventoryTransaction(Map<String, dynamic> inventoryData) async {

--- a/lib/backend/inventory/closing_balance_api_service.dart
+++ b/lib/backend/inventory/closing_balance_api_service.dart
@@ -1,11 +1,12 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class ClosingBalanceApiService {
   final String baseUrl;
 
-  ClosingBalanceApiService(this.baseUrl);
+  ClosingBalanceApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   // Fetch closing balance for all ingredients
   Future<List<dynamic>> fetchAllClosingBalances() async {

--- a/lib/backend/inventory/purchase_item_service.dart
+++ b/lib/backend/inventory/purchase_item_service.dart
@@ -1,11 +1,12 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class PurchaseItemService {
   final String baseUrl;
 
-  PurchaseItemService(this.baseUrl);
+  PurchaseItemService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   Future<List<dynamic>> getAllPurchaseItems() async {
     final response = await http.get(Uri.parse('$baseUrl/purchase-items'));

--- a/lib/backend/inventory/stock_movement_service.dart
+++ b/lib/backend/inventory/stock_movement_service.dart
@@ -1,11 +1,12 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class StockMovementService {
   final String baseUrl;
 
-  StockMovementService({required this.baseUrl});
+  StockMovementService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   // Get all stock movements
   Future<List<dynamic>> getAllStockMovements() async {

--- a/lib/backend/inventory/vendor_payment_service.dart
+++ b/lib/backend/inventory/vendor_payment_service.dart
@@ -1,11 +1,12 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class VendorPaymentService {
   final String baseUrl;
 
-  VendorPaymentService(this.baseUrl);
+  VendorPaymentService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   // Get all vendor payments
   Future<List<dynamic>> getAllVendorPayments() async {

--- a/lib/backend/inventory/vendor_service.dart
+++ b/lib/backend/inventory/vendor_service.dart
@@ -1,11 +1,12 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class VendorService {
   final String baseUrl;
 
-  VendorService(this.baseUrl);
+  VendorService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   Future<List<dynamic>> getAllVendors() async {
     final response = await http.get(Uri.parse('$baseUrl/vendors'));

--- a/lib/backend/loyalty/applied_discount_api_service.dart
+++ b/lib/backend/loyalty/applied_discount_api_service.dart
@@ -1,11 +1,12 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class AppliedDiscountApiService {
   final String baseUrl;
 
-  AppliedDiscountApiService(this.baseUrl);
+  AppliedDiscountApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   // Fetch all applied discounts
   Future<List<dynamic>> fetchAppliedDiscounts() async {

--- a/lib/backend/loyalty/loyalty_api_service.dart
+++ b/lib/backend/loyalty/loyalty_api_service.dart
@@ -1,11 +1,12 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class LoyaltyApiService {
   final String baseUrl;
 
-  LoyaltyApiService(this.baseUrl);
+  LoyaltyApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   // Create or update customer loyalty points
   Future<Map<String, dynamic>> addOrUpdateLoyaltyPoints(

--- a/lib/backend/order/OrderApiService.dart
+++ b/lib/backend/order/OrderApiService.dart
@@ -1,11 +1,12 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class OrderApiService {
   final String baseUrl;
 
-  OrderApiService({required this.baseUrl});
+  OrderApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   // 1. Create Order
   Future<Map<String, dynamic>> createOrder(

--- a/lib/backend/order/items_api_service.dart
+++ b/lib/backend/order/items_api_service.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class ItemsApiService {
   final String baseUrl; // Replace with your server URL
-  ItemsApiService({required this.baseUrl});
+  ItemsApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
   // Fetch all items
   Future<List<dynamic>> fetchAllItems() async {
     try {

--- a/lib/backend/order/waiterApiService.dart
+++ b/lib/backend/order/waiterApiService.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class WaiterApiService {
   final String baseUrl;
 
-  WaiterApiService({required this.baseUrl});
+  WaiterApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   // 1. Create a new waiter
   Future<Map<String, dynamic>> createWaiter(

--- a/lib/backend/payroll/salary_advance_service.dart
+++ b/lib/backend/payroll/salary_advance_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import 'dart:developer';
 import '../api_config.dart';
 
 class SalaryAdvanceService {
@@ -28,7 +29,7 @@ class SalaryAdvanceService {
         return jsonDecode(response.body);
       }
     } catch (e) {
-      print("Error adding salary advance: $e");
+      log('Error adding salary advance: $e');
     }
     return null;
   }
@@ -40,7 +41,7 @@ class SalaryAdvanceService {
         return jsonDecode(response.body);
       }
     } catch (e) {
-      print("Error fetching salary advances: $e");
+      log('Error fetching salary advances: $e');
     }
     return null;
   }
@@ -52,7 +53,7 @@ class SalaryAdvanceService {
         return jsonDecode(response.body);
       }
     } catch (e) {
-      print("Error fetching salary advance: $e");
+      log('Error fetching salary advance: $e');
     }
     return null;
   }
@@ -78,7 +79,7 @@ class SalaryAdvanceService {
         return jsonDecode(response.body);
       }
     } catch (e) {
-      print("Error updating salary advance: $e");
+      log('Error updating salary advance: $e');
     }
     return null;
   }
@@ -90,7 +91,7 @@ class SalaryAdvanceService {
         return true;
       }
     } catch (e) {
-      print("Error deleting salary advance: $e");
+      log('Error deleting salary advance: $e');
     }
     return false;
   }

--- a/lib/backend/reservation/reservationApiService.dart
+++ b/lib/backend/reservation/reservationApiService.dart
@@ -1,11 +1,12 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class ReservationApiService {
   final String baseUrl;
 
-  ReservationApiService({required this.baseUrl});
+  ReservationApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   // 1. Get all reservations
   Future<List<Map<String, dynamic>>> getReservations() async {

--- a/lib/backend/settings/bill_api_service.dart
+++ b/lib/backend/settings/bill_api_service.dart
@@ -1,11 +1,12 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class BillApiService {
   final String baseUrl;
 
-  BillApiService(this.baseUrl);
+  BillApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   Future<List<dynamic>> fetchConfigurations() async {
     final response = await http.get(Uri.parse('$baseUrl/'));

--- a/lib/backend/settings/category_api_service.dart
+++ b/lib/backend/settings/category_api_service.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class CategoryApiService {
   final String baseUrl;
 
-  CategoryApiService({required this.baseUrl});
+  CategoryApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   // 1. Create a new category
   Future<Map<String, dynamic>> createCategory(

--- a/lib/backend/settings/date_config_api_service.dart
+++ b/lib/backend/settings/date_config_api_service.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class DateConfigApiService {
   final String baseUrl;
 
-  DateConfigApiService({required this.baseUrl});
+  DateConfigApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   // 1. Create a new date configuration
   Future<Map<String, dynamic>> createDateConfig(

--- a/lib/backend/settings/deliveryApiService.dart
+++ b/lib/backend/settings/deliveryApiService.dart
@@ -2,12 +2,13 @@ import 'dart:convert';
 
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 import 'package:point_of_sale_system/model/delivery_charge_model.dart';
 
 class DeliveryApiService {
   final String baseUrl;
 
-  DeliveryApiService({required this.baseUrl});
+  DeliveryApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   Future<void> _ensureBoxesOpen() async {
     if (!Hive.isBoxOpen('delivery')) {

--- a/lib/backend/settings/discountApiService.dart
+++ b/lib/backend/settings/discountApiService.dart
@@ -2,12 +2,13 @@ import 'dart:convert';
 
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 import 'package:point_of_sale_system/model/discount_model.dart';
 
 class DiscountApiService {
   final String baseUrl;
 
-  DiscountApiService({required this.baseUrl});
+  DiscountApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   // 1. Get all discount configurations
   Future<void> _ensureBoxesOpen() async {

--- a/lib/backend/settings/happy_hour_service.dart
+++ b/lib/backend/settings/happy_hour_service.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class HappyHourApiService {
   final String baseUrl;
 
-  HappyHourApiService({required this.baseUrl});
+  HappyHourApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   // 1. Create a new happy hour configuration
   Future<Map<String, dynamic>> createHappyHourConfig(Map<String, dynamic> happyHourData) async {

--- a/lib/backend/settings/kotConfigApiService.dart
+++ b/lib/backend/settings/kotConfigApiService.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class KOTConfigApiService {
   final String baseUrl;
 
-  KOTConfigApiService({required this.baseUrl});
+  KOTConfigApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   // 1. Create a new KOT configuration
   Future<Map<String, dynamic>> createKOTConfig(

--- a/lib/backend/settings/outlet_service.dart
+++ b/lib/backend/settings/outlet_service.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class OutletApiService {
   final String baseUrl;
 
-  OutletApiService({required this.baseUrl});
+  OutletApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   Future<List<dynamic>> getAllProperties() async {
     final url = Uri.parse("$baseUrl/properties");

--- a/lib/backend/settings/packingChargeApiService.dart
+++ b/lib/backend/settings/packingChargeApiService.dart
@@ -2,12 +2,13 @@ import 'dart:convert';
 
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 import 'package:point_of_sale_system/model/packing_charge_model.dart';
 
 class PackingChargeApiService {
   final String baseUrl;
 
-  PackingChargeApiService({required this.baseUrl});
+  PackingChargeApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   Future<void> _ensureBoxesOpen() async {
     if (!Hive.isBoxOpen('packing')) {

--- a/lib/backend/settings/payment_method_service.dart
+++ b/lib/backend/settings/payment_method_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import 'dart:developer';
 import '../api_config.dart';
 
 class PaymentMethodService {
@@ -20,7 +21,7 @@ class PaymentMethodService {
     if (response.statusCode == 201) {
       return jsonDecode(response.body);
     } else {
-      print("Error adding payment method: ${response.body}");
+      log('Error adding payment method: ${response.body}');
       return null;
     }
   }
@@ -30,7 +31,7 @@ class PaymentMethodService {
     if (response.statusCode == 200) {
       return jsonDecode(response.body);
     } else {
-      print("Error fetching payment methods: ${response.body}");
+      log('Error fetching payment methods: ${response.body}');
       return null;
     }
   }
@@ -40,7 +41,7 @@ class PaymentMethodService {
     if (response.statusCode == 200) {
       return jsonDecode(response.body);
     } else {
-      print("Error fetching payment method: ${response.body}");
+      log('Error fetching payment method: ${response.body}');
       return null;
     }
   }
@@ -59,7 +60,7 @@ class PaymentMethodService {
     if (response.statusCode == 200) {
       return jsonDecode(response.body);
     } else {
-      print("Error updating payment method: ${response.body}");
+      log('Error updating payment method: ${response.body}');
       return null;
     }
   }
@@ -69,7 +70,7 @@ class PaymentMethodService {
     if (response.statusCode == 200) {
       return true;
     } else {
-      print("Error deleting payment method: ${response.body}");
+      log('Error deleting payment method: ${response.body}');
       return false;
     }
   }

--- a/lib/backend/settings/platformFeeApiService.dart
+++ b/lib/backend/settings/platformFeeApiService.dart
@@ -1,11 +1,12 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class PlatformFeeApiService {
   final String baseUrl;
 
-  PlatformFeeApiService({required this.baseUrl});
+  PlatformFeeApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   // 1. Get all platform fee configurations
   Future<List<Map<String, dynamic>>> getPlatformFees() async {

--- a/lib/backend/settings/printerApiService.dart
+++ b/lib/backend/settings/printerApiService.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class PrinterApiService {
   final String baseUrl;
 
-  PrinterApiService({required this.baseUrl});
+  PrinterApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   // 1. Get all printer configurations
   Future<List<Map<String, dynamic>>> getPrinters() async {

--- a/lib/backend/settings/serviceChargeApiService.dart
+++ b/lib/backend/settings/serviceChargeApiService.dart
@@ -2,12 +2,13 @@ import 'dart:convert';
 
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 import 'package:point_of_sale_system/model/service_charge_model.dart';
 
 class ServiceChargeApiService {
   final String baseUrl;
 
-  ServiceChargeApiService({required this.baseUrl});
+  ServiceChargeApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   Future<void> _ensureBoxesOpen() async {
     if (!Hive.isBoxOpen('service')) {

--- a/lib/backend/settings/subcategoryApiService.dart
+++ b/lib/backend/settings/subcategoryApiService.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class SubcategoryApiService {
   final String baseUrl;
 
-  SubcategoryApiService({required this.baseUrl});
+  SubcategoryApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   // 1. Get all subcategories
   Future<List<Map<String, dynamic>>> getSubcategories() async {

--- a/lib/backend/settings/taxConfigApiService.dart
+++ b/lib/backend/settings/taxConfigApiService.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class TaxConfigApiService {
   final String baseUrl;
 
-  TaxConfigApiService({required this.baseUrl});
+  TaxConfigApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   // 1. Get Tax Configuration by ID
   Future<Map<String, dynamic>> getTaxConfigById(String id) async {

--- a/lib/backend/settings/tax_service.dart
+++ b/lib/backend/settings/tax_service.dart
@@ -1,11 +1,12 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class TaxService {
   final String baseUrl;
 
-  TaxService(this.baseUrl);
+  TaxService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   Future<List<Map<String, dynamic>>> getTaxes() async {
     final response = await http.get(Uri.parse('$baseUrl/taxes'));

--- a/lib/backend/settings/user_api_service.dart
+++ b/lib/backend/settings/user_api_service.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class UserApiService {
   final String baseUrl;
 
-  UserApiService({required this.baseUrl});
+  UserApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   Future<List<Map<String, dynamic>>> getUsers() async {
     final response = await http.get(Uri.parse('$baseUrl/users'));

--- a/lib/backend/settings/user_permissions.dart
+++ b/lib/backend/settings/user_permissions.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import '../api_config.dart';
 
 class UserPermissionApiService {
   final String baseUrl;
 
-  UserPermissionApiService({required this.baseUrl});
+  UserPermissionApiService({String? baseUrl}) : baseUrl = baseUrl ?? apiBaseUrl;
 
   // 1. Create a new user permission
   Future<Map<String, dynamic>> createUserPermission(Map<String, dynamic> userPermissionData) async {

--- a/lib/screens/admin/admin.dart
+++ b/lib/screens/admin/admin.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:point_of_sale_system/screens/payroll/payrollDashboard.dart';
 
 import '../../backend/billing/bill_service.dart';
-import '../../backend/api_config.dart';
 import '../billing/billconfig.dart';
 import '../billing/guest_info.dart';
 import '../expense/expenseDashboard.dart';
@@ -45,8 +44,7 @@ class _AdminDashboard extends State {
   String selectedOutlet = 'Restaurant';
   final List<String> outlets = ['Outlet1', 'Outlet2'];
   ChartType chartType = ChartType.line;
-  final BillingApiService billingApiService =
-      BillingApiService(baseUrl: apiBaseUrl);
+  final BillingApiService billingApiService = BillingApiService();
   String today_growth = "0";
   String today_sales = "0";
   String this_week_sales = "0";

--- a/lib/screens/billing/bill_old.dart
+++ b/lib/screens/billing/bill_old.dart
@@ -8,7 +8,6 @@ import 'package:pdf/widgets.dart' as pw;
 
 import '../../backend/billing/bill_service.dart';
 import '../../backend/order/OrderApiService.dart';
-import '../../backend/api_config.dart';
 import '../orders/modifyOrder.dart';
 
 class OldBillPage extends StatefulWidget {
@@ -21,8 +20,8 @@ class OldBillPage extends StatefulWidget {
 }
 
 class _OldBillPageState extends State<OldBillPage> {
-  BillingApiService billApiService = BillingApiService(baseUrl: apiBaseUrl);
-  OrderApiService orderApiService = OrderApiService(baseUrl: apiBaseUrl);
+  BillingApiService billApiService = BillingApiService();
+  OrderApiService orderApiService = OrderApiService();
   List<Map<String, String>> _bills = [];
   final List<Map<String, String>> _billsdata = [];
   List<Map<String, dynamic>> orders = [];

--- a/lib/screens/billing/bill_section.dart
+++ b/lib/screens/billing/bill_section.dart
@@ -8,7 +8,6 @@ import 'package:pdf/widgets.dart' as pw;
 
 import '../../backend/billing/bill_service.dart';
 import '../../backend/order/OrderApiService.dart';
-import '../../backend/api_config.dart';
 import '../orders/modifyOrder.dart';
 
 class BillPage extends StatefulWidget {
@@ -21,8 +20,8 @@ class BillPage extends StatefulWidget {
 }
 
 class _BillPageState extends State<BillPage> {
-  BillingApiService billApiService = BillingApiService(baseUrl: apiBaseUrl);
-  OrderApiService orderApiService = OrderApiService(baseUrl: apiBaseUrl);
+  BillingApiService billApiService = BillingApiService();
+  OrderApiService orderApiService = OrderApiService();
   List<Map<String, String>> _bills = [];
   final List<Map<String, String>> _billsdata = [];
   List<Map<String, dynamic>> orders = [];

--- a/lib/screens/billing/billing.dart
+++ b/lib/screens/billing/billing.dart
@@ -13,7 +13,6 @@ import '../../backend/settings/deliveryApiService.dart';
 import '../../backend/settings/discountApiService.dart';
 import '../../backend/settings/packingChargeApiService.dart';
 import '../../backend/settings/serviceChargeApiService.dart';
-import '../../backend/api_config.dart';
 
 class BillingFormScreen extends StatefulWidget {
   final tableno;
@@ -30,16 +29,12 @@ class BillingFormScreen extends StatefulWidget {
 }
 
 class _BillingFormScreenState extends State<BillingFormScreen> {
-  BillingApiService billingApiService = BillingApiService(baseUrl: apiBaseUrl);
-  OrderApiService orderApiService = OrderApiService(baseUrl: apiBaseUrl);
-  GuestRecordApiService guestRecordApiService =
-      GuestRecordApiService(baseUrl: apiBaseUrl);
-  DiscountApiService discountApiService =
-      DiscountApiService(baseUrl: apiBaseUrl);
-  PackingChargeApiService packingApiService =
-      PackingChargeApiService(baseUrl: apiBaseUrl);
-  DeliveryApiService deliveryApiService =
-      DeliveryApiService(baseUrl: apiBaseUrl);
+  BillingApiService billingApiService = BillingApiService();
+  OrderApiService orderApiService = OrderApiService();
+  GuestRecordApiService guestRecordApiService = GuestRecordApiService();
+  DiscountApiService discountApiService = DiscountApiService();
+  PackingChargeApiService packingApiService = PackingChargeApiService();
+  DeliveryApiService deliveryApiService = DeliveryApiService();
   List<Map<dynamic, dynamic>> discountList = [
     {}
   ]; // Variable to store discounts
@@ -49,8 +44,7 @@ class _BillingFormScreenState extends State<BillingFormScreen> {
   ]; // Variable to store discounts
   List<Map<dynamic, dynamic>> serviceList = [{}]; // Variable to store discounts
 
-  ServiceChargeApiService serviceChargeApiService =
-      ServiceChargeApiService(baseUrl: apiBaseUrl);
+  ServiceChargeApiService serviceChargeApiService = ServiceChargeApiService();
 
   final TextEditingController _billNoController = TextEditingController();
   final TextEditingController _orderNoController =

--- a/lib/screens/billing/payments.dart
+++ b/lib/screens/billing/payments.dart
@@ -3,7 +3,6 @@ import 'package:flutter/services.dart';
 
 import '../../backend/billing/bill_service.dart';
 import '../../backend/billing/paymentApiService.dart';
-import '../../backend/api_config.dart';
 
 class PaymentFormScreen extends StatefulWidget {
   final tableno;
@@ -21,10 +20,8 @@ class PaymentFormScreen extends StatefulWidget {
 }
 
 class _PaymentFormScreenState extends State<PaymentFormScreen> {
-  PaymentApiService paymentApiService =
-      PaymentApiService(baseUrl: apiBaseUrl);
-  BillingApiService billApiService =
-      BillingApiService(baseUrl: apiBaseUrl);
+  PaymentApiService paymentApiService = PaymentApiService();
+  BillingApiService billApiService = BillingApiService();
   final _formKey = GlobalKey<FormState>();
   String? _paymentMethod;
   double _amount = 0.0;

--- a/lib/screens/inventory/VendorScreen.dart
+++ b/lib/screens/inventory/VendorScreen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../backend/api_config.dart';
 import '../../backend/inventory/vendor_service.dart';
 
 final vendorProvider = StateProvider<List<Map<String, String>>>((ref) => [
@@ -18,7 +17,7 @@ class VendorScreen extends ConsumerStatefulWidget {
 class _VendorScreenState extends ConsumerState<VendorScreen> {
   final TextEditingController nameController = TextEditingController();
   final TextEditingController contactController = TextEditingController();
-  final VendorService vendorService = VendorService(apiBaseUrl);
+  final VendorService vendorService = VendorService();
 
   @override
   void initState() {

--- a/lib/screens/inventory/closingStockReport.dart
+++ b/lib/screens/inventory/closingStockReport.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:syncfusion_flutter_charts/charts.dart';
-import '../../backend/api_config.dart';
 import '../../backend/inventory/InventoryApiService.dart';
 import '../../backend/inventory/closing_balance_api_service.dart';
 
@@ -12,8 +11,7 @@ class ClosingStockReport extends StatefulWidget {
 }
 
 class _ClosingStockReportState extends State<ClosingStockReport> {
-  final ClosingBalanceApiService _closingService =
-      ClosingBalanceApiService(apiBaseUrl);
+  final ClosingBalanceApiService _closingService = ClosingBalanceApiService();
   List<StockData> stockData = [];
 
   @override

--- a/lib/screens/inventory/inventoryDashboard.dart
+++ b/lib/screens/inventory/inventoryDashboard.dart
@@ -3,7 +3,6 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:syncfusion_flutter_charts/charts.dart';
-import '../../backend/api_config.dart';
 import '../../backend/inventory/InventoryApiService.dart';
 import '../../backend/inventory/closing_balance_api_service.dart';
 
@@ -29,10 +28,8 @@ class InventoryDashboard extends StatefulWidget {
 class _InventoryDashboardState extends State<InventoryDashboard> {
   int _selectedIndex = 0;
 
-  final InventoryApiService _inventoryService =
-      InventoryApiService(baseUrl: apiBaseUrl);
-  final ClosingBalanceApiService _closingService =
-      ClosingBalanceApiService(apiBaseUrl);
+  final InventoryApiService _inventoryService = InventoryApiService();
+  final ClosingBalanceApiService _closingService = ClosingBalanceApiService();
 
   List<SalesData> _transactions = [];
   List<StockItem> _closingStock = [];

--- a/lib/screens/orders/kotform.dart
+++ b/lib/screens/orders/kotform.dart
@@ -7,7 +7,6 @@ import 'package:pdf/widgets.dart' as pw;
 import '../../backend/order/OrderApiService.dart';
 import '../../backend/order/items_api_service.dart';
 import '../../backend/order/waiterApiService.dart';
-import '../../backend/api_config.dart';
 
 class KOTFormScreen extends StatefulWidget {
   final tableno;
@@ -24,9 +23,9 @@ class KOTFormScreen extends StatefulWidget {
 }
 
 class _KOTFormScreenState extends State<KOTFormScreen> {
-  OrderApiService orderApiService = OrderApiService(baseUrl: apiBaseUrl);
-  ItemsApiService itemsApiService = ItemsApiService(baseUrl: apiBaseUrl);
-  WaiterApiService waiterApiService = WaiterApiService(baseUrl: apiBaseUrl);
+  OrderApiService orderApiService = OrderApiService();
+  ItemsApiService itemsApiService = ItemsApiService();
+  WaiterApiService waiterApiService = WaiterApiService();
   final List<String> _categories = ['Starters', 'Main Course', 'Desserts'];
   late Future<Map<String, List<Map<String, String>>>> _menuItemsFuture;
   // Menu items with their tags (Veg/Non-Veg) and rate

--- a/lib/screens/orders/modifyOrder.dart
+++ b/lib/screens/orders/modifyOrder.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 import '../../backend/order/OrderApiService.dart';
 import '../../backend/order/items_api_service.dart';
-import '../../backend/api_config.dart';
 
 class ModifyOrderList extends StatefulWidget {
   final propertyid;
@@ -20,9 +19,9 @@ class ModifyOrderList extends StatefulWidget {
 }
 
 class _ModifyOrderListState extends State<ModifyOrderList> {
-  OrderApiService orderApiService = OrderApiService(baseUrl: apiBaseUrl);
+  OrderApiService orderApiService = OrderApiService();
   final List<String> _categories = ['Starters', 'Main Course', 'Desserts'];
-  ItemsApiService itemsApiService = ItemsApiService(baseUrl: apiBaseUrl);
+  ItemsApiService itemsApiService = ItemsApiService();
   late Future<Map<String, List<Map<String, String>>>> _menuItemsFuture;
   // Menu items with their tags (Veg/Non-Veg) and rate
   final Map<String, List<Map<String, String>>> _menuItems = {

--- a/lib/screens/orders/orderlist.dart
+++ b/lib/screens/orders/orderlist.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import '../../backend/order/OrderApiService.dart';
-import '../../backend/api_config.dart';
 import 'modifyOrder.dart';
 
 class OrderList extends StatefulWidget {
@@ -14,8 +13,7 @@ class OrderList extends StatefulWidget {
 }
 
 class _OrderListState extends State<OrderList> {
-  OrderApiService orderApiService =
-      OrderApiService(baseUrl: apiBaseUrl);
+  OrderApiService orderApiService = OrderApiService();
   List<Map<String, dynamic>> orders = [];
   List<Map<String, dynamic>> orderItems = [];
   var selectedOrderId;

--- a/lib/screens/orders/posmain.dart
+++ b/lib/screens/orders/posmain.dart
@@ -29,8 +29,7 @@ class POSMainScreen extends StatefulWidget {
 
 class _POSMainScreenState extends State<POSMainScreen> {
   final tableapiService = TableApiService(apiUrl: apiBaseUrl);
-  final BillingApiService billingApiService =
-      BillingApiService(baseUrl: apiBaseUrl);
+  final BillingApiService billingApiService = BillingApiService();
   String today_reservations = "0";
   String today_sales = "0";
   String running_orders = "0";

--- a/lib/screens/orders/waiters.dart
+++ b/lib/screens/orders/waiters.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:point_of_sale_system/backend/order/waiterApiService.dart';
-import '../../backend/api_config.dart';
 
 class WaiterConfigurationForm extends StatefulWidget {
   @override
@@ -10,8 +9,7 @@ class WaiterConfigurationForm extends StatefulWidget {
 }
 
 class _WaiterConfigurationFormState extends State<WaiterConfigurationForm> {
-  WaiterApiService waiterApiService =
-      WaiterApiService(baseUrl: apiBaseUrl);
+  WaiterApiService waiterApiService = WaiterApiService();
 
   final _formKey = GlobalKey<FormState>();
   String? selectedOutlet;

--- a/lib/screens/rservation/reservation.dart
+++ b/lib/screens/rservation/reservation.dart
@@ -3,7 +3,6 @@ import 'package:flutter/services.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../backend/reservation/reservationApiService.dart';
-import '../../backend/api_config.dart';
 
 class ReservationFormScreen extends StatefulWidget {
   const ReservationFormScreen({super.key});
@@ -13,8 +12,7 @@ class ReservationFormScreen extends StatefulWidget {
 }
 
 class _ReservationFormScreenState extends State<ReservationFormScreen> {
-  ReservationApiService reservationApiService =
-      ReservationApiService(baseUrl: apiBaseUrl);
+  ReservationApiService reservationApiService = ReservationApiService();
   final _formKey = GlobalKey<FormState>();
   String? _guestName;
   String? _contactInfo;

--- a/lib/screens/settings/ItemManage.dart
+++ b/lib/screens/settings/ItemManage.dart
@@ -11,7 +11,6 @@ import 'package:open_file/open_file.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../../backend/order/items_api_service.dart';
-import '../../backend/api_config.dart';
 
 class ItemMasterScreen extends StatefulWidget {
   const ItemMasterScreen({super.key});
@@ -21,8 +20,7 @@ class ItemMasterScreen extends StatefulWidget {
 }
 
 class _ItemMasterScreenState extends State<ItemMasterScreen> {
-  final ItemsApiService _apiService =
-      ItemsApiService(baseUrl: apiBaseUrl); // Replace with actual base URL
+  final ItemsApiService _apiService = ItemsApiService();
   final List<String> _categories = ['Starters', 'Main Course', 'Desserts'];
   final List<String> tags = ['Veg', 'Non Veg'];
   final List<String> _brands = ['Brand A', 'Brand B', 'Brand C'];

--- a/lib/screens/settings/dateconfig.dart
+++ b/lib/screens/settings/dateconfig.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../backend/settings/date_config_api_service.dart';
-import '../../backend/api_config.dart';
 
 class SoftwareDateConfigForm extends StatefulWidget {
   const SoftwareDateConfigForm({super.key});
@@ -12,8 +11,7 @@ class SoftwareDateConfigForm extends StatefulWidget {
 }
 
 class _SoftwareDateConfigFormState extends State<SoftwareDateConfigForm> {
-  DateConfigApiService dateConfigApiService =
-      DateConfigApiService(baseUrl: apiBaseUrl);
+  DateConfigApiService dateConfigApiService = DateConfigApiService();
 
   final _formKey = GlobalKey<FormState>();
   String? _selectedOutlet;

--- a/lib/screens/settings/kotconfig.dart
+++ b/lib/screens/settings/kotconfig.dart
@@ -3,7 +3,6 @@ import 'package:flutter/services.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../backend/settings/kotConfigApiService.dart';
-import '../../backend/api_config.dart';
 
 class KOTConfigForm extends StatefulWidget {
   const KOTConfigForm({super.key});
@@ -13,8 +12,7 @@ class KOTConfigForm extends StatefulWidget {
 }
 
 class _KOTConfigFormState extends State<KOTConfigForm> {
-  KOTConfigApiService kotConfigApiService =
-      KOTConfigApiService(baseUrl: apiBaseUrl);
+  KOTConfigApiService kotConfigApiService = KOTConfigApiService();
   final _formKey = GlobalKey<FormState>();
   int kotStartingNumber = 1;
   DateTime? startDate;

--- a/lib/screens/settings/outletconfig.dart
+++ b/lib/screens/settings/outletconfig.dart
@@ -3,7 +3,6 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../../backend/settings/outlet_service.dart';
-import '../../backend/api_config.dart';
 
 class OutletConfigurationForm extends StatefulWidget {
   const OutletConfigurationForm({super.key});
@@ -14,8 +13,7 @@ class OutletConfigurationForm extends StatefulWidget {
 }
 
 class _OutletConfigurationFormState extends State<OutletConfigurationForm> {
-  final OutletApiService apiService =
-      OutletApiService(baseUrl: apiBaseUrl);
+  final OutletApiService apiService = OutletApiService();
   List<dynamic> properties = [];
   List<dynamic> outletConfigurations = [];
   bool isLoading = true;

--- a/lib/screens/settings/printer.dart
+++ b/lib/screens/settings/printer.dart
@@ -3,7 +3,6 @@ import 'package:flutter/services.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../backend/settings/printerApiService.dart';
-import '../../backend/api_config.dart';
 
 class PrinterConfigForm extends StatefulWidget {
   const PrinterConfigForm({super.key});
@@ -14,8 +13,7 @@ class PrinterConfigForm extends StatefulWidget {
 
 class _PrinterConfigFormState extends State<PrinterConfigForm> {
   final _formKey = GlobalKey<FormState>();
-  PrinterApiService printerApiService =
-      PrinterApiService(baseUrl: apiBaseUrl);
+  PrinterApiService printerApiService = PrinterApiService();
   TextEditingController printerNumberController = TextEditingController();
   String printerName = '';
   String printerType = 'receipt';

--- a/lib/screens/settings/propertyinfo.dart
+++ b/lib/screens/settings/propertyinfo.dart
@@ -3,7 +3,6 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../../backend/settings/outlet_service.dart';
-import '../../backend/api_config.dart';
 import '../../backend/settings/property_service.dart';
 
 class PropertyConfigurationForm extends StatefulWidget {
@@ -36,8 +35,7 @@ class _PropertyConfigurationFormState extends State<PropertyConfigurationForm> {
     _fetchProperties();
   }
 
-  final OutletApiService apiService =
-      OutletApiService(baseUrl: apiBaseUrl);
+  final OutletApiService apiService = OutletApiService();
   List<dynamic> properties = [];
   List<dynamic> outletConfigurations = [];
 

--- a/lib/screens/settings/userpermission.dart
+++ b/lib/screens/settings/userpermission.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:point_of_sale_system/backend/settings/user_permissions.dart';
-import '../../backend/api_config.dart';
 
 class UserPermissionForm extends StatefulWidget {
   const UserPermissionForm({super.key});
@@ -12,8 +11,7 @@ class UserPermissionForm extends StatefulWidget {
 
 class _UserPermissionFormState extends State<UserPermissionForm> {
   final _formKey = GlobalKey<FormState>();
-  UserPermissionApiService userPermissionApiService =
-      UserPermissionApiService(baseUrl: apiBaseUrl);
+  UserPermissionApiService userPermissionApiService = UserPermissionApiService();
   List<String> selectedOutlets = [];
   List<String> selectedUsers = []; // List to store selected user ids
   Map<String, List<String>> userPermissions =


### PR DESCRIPTION
## Summary
- add `api_config.dart` imports and default `apiBaseUrl` in many services
- replace print statements with `log` calls
- update screens to use services without specifying a base URL

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856784bb3dc8328b72f99efbe9db4a6