### PR TITLE
Implement bill update API

### DIFF
--- a/global_server_single_use/routes/billing.js
+++ b/global_server_single_use/routes/billing.js
@@ -497,6 +497,144 @@ router.post('/', async (req, res) => {
   }
 });
 
+// Update bill details and recalculate totals
+router.put('/:id', async (req, res) => {
+  const billId = req.params.id;
+  const {
+    table_no,
+    tax_value,
+    discount_percentage,
+    service_charge_percentage,
+    packing_charge_percentage,
+    delivery_charge_percentage,
+    other_charge,
+    totalamount,
+    subtotal,
+    property_id,
+    outletname,
+    billstatus,
+    bill_number,
+    pax,
+    guestId,
+    guestName,
+    platform_fees_percentage,
+    platform_fees_tax,
+    platform_fees_tax_per,
+    packing_charge_tax,
+    delivery_charge_tax,
+    service_charge_tax,
+    packing_charge_tax_per,
+    delivery_charge_tax_per,
+    service_charge_tax_per
+  } = req.body;
+
+  try {
+    const totalAmount = Number(totalamount).toFixed(2);
+    const subTotal = Number(subtotal).toFixed(2);
+
+    const discount_value = (totalAmount * (discount_percentage / 100)).toFixed(2);
+    const service_charge_value = (subTotal * (service_charge_percentage / 100)).toFixed(2);
+    const packing_charge = (subTotal * (packing_charge_percentage / 100)).toFixed(2);
+    const delivery_charge = (subTotal * (delivery_charge_percentage / 100)).toFixed(2);
+    const platform_fees = (subTotal * (platform_fees_percentage / 100)).toFixed(2);
+
+    const grand_total = (
+      parseFloat(totalAmount) -
+      parseFloat(discount_value) +
+      parseFloat(tax_value) +
+      parseFloat(service_charge_value) +
+      parseFloat(packing_charge) +
+      parseFloat(delivery_charge) +
+      parseFloat(platform_fees) +
+      parseFloat(other_charge || 0) +
+      parseFloat(platform_fees_tax || 0) +
+      parseFloat(packing_charge_tax || 0) +
+      parseFloat(delivery_charge_tax || 0) +
+      parseFloat(service_charge_tax || 0)
+    ).toFixed(2);
+
+    const updateQuery = `
+      UPDATE bills SET
+        bill_number = $1,
+        total_amount = $2,
+        tax_value = $3,
+        discount_value = $4,
+        service_charge_value = $5,
+        packing_charge = $6,
+        delivery_charge = $7,
+        other_charge = $8,
+        grand_total = $9,
+        property_id = $10,
+        outlet_name = $11,
+        packing_charge_percentage = $12,
+        delivery_charge_percentage = $13,
+        discount_percentage = $14,
+        service_charge_percentage = $15,
+        status = $16,
+        table_no = $17,
+        pax = $18,
+        guestId = $19,
+        guestName = $20,
+        platform_fees = $21,
+        platform_fees_tax = $22,
+        platform_fees_tax_per = $23,
+        packing_charge_tax = $24,
+        delivery_charge_tax = $25,
+        service_charge_tax = $26,
+        packing_charge_tax_per = $27,
+        delivery_charge_tax_per = $28,
+        service_charge_tax_per = $29,
+        subtotal = $30,
+        updated_at = CURRENT_TIMESTAMP
+      WHERE id = $31 RETURNING id`;
+
+    const updateValues = [
+      bill_number,
+      totalAmount,
+      tax_value,
+      discount_value,
+      service_charge_value,
+      packing_charge,
+      delivery_charge,
+      other_charge,
+      grand_total,
+      property_id,
+      outletname,
+      packing_charge_percentage,
+      delivery_charge_percentage,
+      discount_percentage,
+      service_charge_percentage,
+      billstatus,
+      table_no,
+      pax,
+      guestId,
+      guestName,
+      platform_fees,
+      platform_fees_tax,
+      platform_fees_tax_per,
+      packing_charge_tax,
+      delivery_charge_tax,
+      service_charge_tax,
+      packing_charge_tax_per,
+      delivery_charge_tax_per,
+      service_charge_tax_per,
+      subTotal,
+      billId
+    ];
+
+    const result = await pool.query(updateQuery, updateValues);
+
+    res.status(200).json({
+      message: 'Bill updated successfully',
+      billId: result.rows[0].id,
+      grand_total
+    });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Failed to update bill', details: error.message });
+  }
+});
+
 
 
 async function fetchSalesData() {

--- a/lib/backend/billing/bill_service.dart
+++ b/lib/backend/billing/bill_service.dart
@@ -110,7 +110,7 @@ class BillingApiService {
   Future<Map<String, dynamic>> editBill(
       String orderId, Map<String, dynamic> billData) async {
     final response = await http.put(
-      Uri.parse('$baseUrl/$orderId/edit-bill'),
+      Uri.parse('$baseUrl/bill/$orderId'),
       headers: {'Content-Type': 'application/json'},
       body: json.encode(billData),
     );


### PR DESCRIPTION
## Summary
- add PUT /api/bill/:id route to update bills
- recalc totals server-side
- update BillingApiService to use new endpoint

## Testing
- `flutter test` *(fails: command not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857bb5b0cac8328a0eddf509305b671