### PR TITLE
Improve PDF open logic per OS

### DIFF
--- a/lib/screens/billing/bill_section.dart
+++ b/lib/screens/billing/bill_section.dart
@@ -950,8 +950,12 @@ class _BillPageState extends State<BillPage> {
       SnackBar(content: Text('PDF saved at: $filePath')),
     );
 
-    if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
+    if (Platform.isWindows) {
       await Process.run('explorer', [filePath]);
+    } else if (Platform.isMacOS) {
+      await Process.run('open', [filePath]);
+    } else if (Platform.isLinux) {
+      await Process.run('xdg-open', [filePath]);
     }
   }
 


### PR DESCRIPTION
## Summary
- update `_generateReprintPDF` to open the saved PDF with appropriate OS command

## Testing
- `npm test` *(fails: Missing script)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857bb5be15c8328a566d55e5583f2a2